### PR TITLE
Implement adaptative navigation

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-01-05T18:17:28.601612250Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/home/ctw03026/.android/avd/Pixel_7_Pro_API_33.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
       <SelectionState runConfigName="LineChartPreview">
         <option name="selectionMode" value="DROPDOWN" />

--- a/app/src/main/java/com/amoferreira/cryptotracker/MainActivity.kt
+++ b/app/src/main/java/com/amoferreira/cryptotracker/MainActivity.kt
@@ -1,62 +1,27 @@
 package com.amoferreira.cryptotracker
 
+import android.os.Build
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.amoferreira.cryptotracker.core.presentation.util.ObserveAsEvents
-import com.amoferreira.cryptotracker.core.presentation.util.toString
-import com.amoferreira.cryptotracker.crypto.presentation.coindetail.CoinDetailScreen
-import com.amoferreira.cryptotracker.crypto.presentation.coinlist.CoinListEvent
-import com.amoferreira.cryptotracker.crypto.presentation.coinlist.CoinListViewModel
-import com.amoferreira.cryptotracker.crypto.presentation.coinlist.components.CoinListScreen
+import com.amoferreira.cryptotracker.core.domain.util.AdaptativeCoinListDetailPane
 import com.amoferreira.cryptotracker.ui.theme.CryptoTrackerTheme
-import org.koin.androidx.compose.koinViewModel
 
 class MainActivity : ComponentActivity() {
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             CryptoTrackerTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    val viewModel = koinViewModel<CoinListViewModel>()
-                    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-                    val context = LocalContext.current
-                    ObserveAsEvents(events = viewModel.events) { event ->
-                        when (event) {
-                            is CoinListEvent.Error -> {
-                                Toast.makeText(
-                                    context,
-                                    event.error.toString(context),
-                                    Toast.LENGTH_LONG,
-                                ).show()
-                            }
-                        }
-                    }
-                    when {
-                        uiState.selectedCoin != null -> {
-                            CoinDetailScreen(
-                                uiState = uiState,
-                                modifier = Modifier.padding(innerPadding)
-                            )
-                        }
-                        else -> {
-                            CoinListScreen(
-                                uiState = uiState,
-                                onAction = viewModel::onAction,
-                                modifier = Modifier.padding(innerPadding),
-                            )
-                        }
-                    }
+                    AdaptativeCoinListDetailPane(modifier = Modifier.padding(innerPadding))
                 }
             }
         }

--- a/app/src/main/java/com/amoferreira/cryptotracker/core/domain/util/AdaptativeCoinListDetailPane(.kt
+++ b/app/src/main/java/com/amoferreira/cryptotracker/core/domain/util/AdaptativeCoinListDetailPane(.kt
@@ -1,0 +1,72 @@
+package com.amoferreira.cryptotracker.core.domain.util
+
+import android.os.Build
+import android.widget.Toast
+import androidx.annotation.RequiresApi
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.AnimatedPane
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.navigation.NavigableListDetailPaneScaffold
+import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.amoferreira.cryptotracker.core.presentation.util.ObserveAsEvents
+import com.amoferreira.cryptotracker.core.presentation.util.toString
+import com.amoferreira.cryptotracker.crypto.presentation.coindetail.CoinDetailScreen
+import com.amoferreira.cryptotracker.crypto.presentation.coinlist.CoinListAction
+import com.amoferreira.cryptotracker.crypto.presentation.coinlist.CoinListEvent
+import com.amoferreira.cryptotracker.crypto.presentation.coinlist.CoinListScreen
+import com.amoferreira.cryptotracker.crypto.presentation.coinlist.CoinListViewModel
+import org.koin.androidx.compose.koinViewModel
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun AdaptativeCoinListDetailPane(
+    viewModel: CoinListViewModel = koinViewModel(),
+    modifier: Modifier = Modifier,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    ObserveAsEvents(events = viewModel.events) { event ->
+        when (event) {
+            is CoinListEvent.Error -> {
+                Toast.makeText(
+                    context,
+                    event.error.toString(context),
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+        }
+    }
+
+    val navigator = rememberListDetailPaneScaffoldNavigator<Any>()
+    NavigableListDetailPaneScaffold(
+        navigator = navigator,
+        listPane = {
+            AnimatedPane {
+                CoinListScreen(
+                    uiState = uiState,
+                    onAction = { action ->
+                        viewModel.onAction(action)
+                        when(action) {
+                            is CoinListAction.OnCoinClick -> {
+                                viewModel.onAction(action)
+                                navigator.navigateTo(
+                                    pane = ListDetailPaneScaffoldRole.Detail,
+                                )
+                            }
+                        }
+                    }
+                )
+            }
+        },
+        detailPane = {
+            CoinDetailScreen(uiState = uiState)
+        },
+        modifier = modifier,
+    )
+}

--- a/app/src/main/java/com/amoferreira/cryptotracker/crypto/presentation/coinlist/CoinListScreen.kt
+++ b/app/src/main/java/com/amoferreira/cryptotracker/crypto/presentation/coinlist/CoinListScreen.kt
@@ -1,4 +1,4 @@
-package com.amoferreira.cryptotracker.crypto.presentation.coinlist.components
+package com.amoferreira.cryptotracker.crypto.presentation.coinlist
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -14,7 +14,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import com.amoferreira.cryptotracker.crypto.presentation.coinlist.CoinListAction
+import com.amoferreira.cryptotracker.crypto.presentation.coinlist.components.CoinListItem
+import com.amoferreira.cryptotracker.crypto.presentation.coinlist.components.CoinListState
+import com.amoferreira.cryptotracker.crypto.presentation.coinlist.components.previewCoin
 import com.amoferreira.cryptotracker.ui.theme.CryptoTrackerTheme
 
 @Composable


### PR DESCRIPTION
Implement adaptive navigation, so that in larger devices or landscape configuration, the list of coins and the details screen for the selected one share the screen, while in portrait configuration, they are in separate screen.

[Crypto-Tracker-Demo.webm](https://github.com/user-attachments/assets/4087b28b-e85b-4bbf-918f-debceb678725)
